### PR TITLE
Python 3 support and get/set item magic methods on DMXConnection.

### DIFF
--- a/pyenttec.py
+++ b/pyenttec.py
@@ -213,6 +213,17 @@ class DMXConnection(object):
                                   "DMX uses 8bit unsigned values (0-255)."
                                   .format(chan, len(self.dmx_frame)))
 
+    def __setitem__(self, chan, val):
+        self.set_channel(chan, val)
+
+    def __getitem__(self, chan):
+        try:
+            return self.dmx_frame[chan]
+        except IndexError:
+            raise DMXAddressError("Channel index {} out of range. "
+                                  "Universe size is {}."
+                                  .format(chan, len(self.dmx_frame)))
+
     def blackout(self):
         """Zero all DMX values."""
         self.dmx_frame = array('B', b'\x00' * len(self.dmx_frame))

--- a/pyenttec.py
+++ b/pyenttec.py
@@ -4,6 +4,10 @@ import serial, sys
 import os
 from array import array
 
+PY2 = sys.version_info[0] == 2
+if PY2:
+    input = raw_input
+
 _START_VAL = 0x7E
 _END_VAL = 0xE7
 
@@ -63,14 +67,14 @@ def select_port(auto=True):
 
     # select an enttec:
     if len(ports) == 0:
-        selection = raw_input("No enttec ports found; enter y to use a mock: ")
+        selection = input("No enttec ports found; enter y to use a mock: ")
         if selection == 'y':
             return DMXConnectionOffline('offline port')
         raise EnttecPortOpenError("No enttec ports found.")
     elif len(ports) == 1 and auto:
         selection = 0
     else:
-        selection = int(raw_input("Select a port by number:"))
+        selection = int(input("Select a port by number:"))
     try:
         port_name = ports[selection]
     except IndexError:

--- a/pyenttec/__init__.py
+++ b/pyenttec/__init__.py
@@ -216,10 +216,9 @@ class DMXConnection(object):
         except OverflowError:
             raise DMXOverflowError("Channel value {} out of range. "
                                   "DMX uses 8bit unsigned values (0-255)."
-                                  .format(chan, len(self.dmx_frame)))
+                                  .format(chan))
 
-    def __setitem__(self, chan, val):
-        self.set_channel(chan, val)
+    __setitem__ = set_channel
 
     def __getitem__(self, chan):
         try:

--- a/pyenttec/__init__.py
+++ b/pyenttec/__init__.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import serial, sys
 import os
 from array import array
+import struct
 
 PY2 = sys.version_info[0] == 2
 if PY2:
@@ -16,7 +17,7 @@ _COM_TIMEOUT = 1
 _MIN_DMX_SIZE = 24
 _MAX_DMX_SIZE = 512
 
-_PACKET_END = _END_VAL.to_bytes(1, 'big')
+_PACKET_END = struct.pack('>B', _END_VAL)
 
 _port_directory = {'darwin': "/dev/",}
 _port_basenames = {'darwin': ["tty.usbserial"],}

--- a/pyenttec/__init__.py
+++ b/pyenttec/__init__.py
@@ -206,9 +206,14 @@ class DMXConnection(object):
 
         Raises IndexError for out of bounds address.
 
-        Raises OverflowError for out of bounds value.
+        Raises ValueError for out of bounds value.
         """
-        self.dmx_frame[chan] = val
+        try:
+            self.dmx_frame[chan] = val
+        except OverflowError:
+            raise ValueError("Channel value {} out of range. " 
+                             "DMX uses 8bit unsigned values (0-255)." 
+                             .format(chan))
 
     __setitem__ = set_channel
 

--- a/pyenttec/__init__.py
+++ b/pyenttec/__init__.py
@@ -222,7 +222,7 @@ class DMXConnection(object):
 
     def blackout(self):
         """Zero all DMX values."""
-        self.dmx_frame = array('B', b'\x00' * len(self.dmx_frame))
+        self.dmx_frame[:] = array('B', b'\x00' * len(self.dmx_frame))
 
     def close(self):
         """Close the port manually."""

--- a/pyenttec/__init__.py
+++ b/pyenttec/__init__.py
@@ -205,28 +205,16 @@ class DMXConnection(object):
     def set_channel(self, chan, val):
         """Set the value of a DMX channel, indexed from 0.
 
-        Raises DMXAddressError for out of bounds address.
+        Raises IndexError for out of bounds address.
+
+        Raises OverflowError for out of bounds value.
         """
-        try:
-            self.dmx_frame[chan] = val
-        except IndexError:
-            raise DMXAddressError("Channel index {} out of range. "
-                                  "Universe size is {}."
-                                  .format(chan, len(self.dmx_frame)))
-        except OverflowError:
-            raise DMXOverflowError("Channel value {} out of range. "
-                                  "DMX uses 8bit unsigned values (0-255)."
-                                  .format(chan))
+        self.dmx_frame[chan] = val
 
     __setitem__ = set_channel
 
     def __getitem__(self, chan):
-        try:
-            return self.dmx_frame[chan]
-        except IndexError:
-            raise DMXAddressError("Channel index {} out of range. "
-                                  "Universe size is {}."
-                                  .format(chan, len(self.dmx_frame)))
+        return self.dmx_frame[chan]
 
     def blackout(self):
         """Zero all DMX values."""
@@ -260,13 +248,4 @@ class EnttecPortOpenError(EnttecError):
     pass
 
 class EnttecConfigError(EnttecError):
-    pass
-
-class DMXError(Exception):
-    pass
-
-class DMXAddressError(DMXError):
-    pass
-
-class DMXOverflowError(DMXError):
     pass

--- a/pyenttec/__init__.py
+++ b/pyenttec/__init__.py
@@ -213,7 +213,7 @@ class DMXConnection(object):
         except OverflowError:
             raise ValueError("Channel value {} out of range. " 
                              "DMX uses 8bit unsigned values (0-255)." 
-                             .format(chan))
+                             .format(val))
 
     __setitem__ = set_channel
 

--- a/pyenttec/__init__.py
+++ b/pyenttec/__init__.py
@@ -102,19 +102,18 @@ class EnttecProParams(object):
 
     def to_packet(self):
         """Format these parameters into a serial packet to send to the port."""
-        payload = [self._user_size_lsb,
+        payload = (self._user_size_lsb,
                    self._user_size_msb,
                    self._break_time,
                    self._mark_after_break_time,
-                   self.refresh_rate]
+                   self.refresh_rate)
         length = len(payload)
-        packet = [_START_VAL,
+        header = (_START_VAL,
                   PortActions.SetParameters,
                   length & 0xFF,
-                  (length >> 8) & 0xFF]
-        packet += payload
-        packet.append(_END_VAL)
-        return array('B', packet).tostring()
+                  (length >> 8) & 0xFF)
+        packet = header + payload
+        return array('B', packet).tostring() + _PACKET_END
 
 
 class DMXConnection(object):
@@ -184,18 +183,18 @@ class DMXConnection(object):
         univ_size = len(self.dmx_frame)
 
         # need to add a pad byte to the serial packet before the DMX payload
-        packet_start = [_START_VAL,
+        packet_start = (_START_VAL,
                         PortActions.SendDMXPacket,
                         (univ_size + 1) & 0xFF,
                         ( (univ_size + 1) >> 8) & 0xFF,
-                        0]
+                        0)
         self._packet_start = array('B', packet_start).tostring()
 
         self._write_settings()
 
     def _write_settings(self):
         """Write the current settings to the port."""
-        self.com.write(self._port_params.to_packet() + _PACKET_END)
+        self.com.write(self._port_params.to_packet())
 
     def render(self):
         """Write the current DMX frame to the port."""

--- a/pyenttec/test.py
+++ b/pyenttec/test.py
@@ -14,8 +14,10 @@ def test_offline_port():
 
     port.set_channel(0, 1)
     assert_equal(1, port.dmx_frame[0])
+    assert_equal(1, port[0])
 
     assert_raises(DMXAddressError, port.set_channel, univ_size, 0)
+    assert_raises(DMXAddressError, lambda c, v: port[c] = v, univ_size, 0)
 
 def test_dmx_value_range():
     port = get_test_port()

--- a/pyenttec/test.py
+++ b/pyenttec/test.py
@@ -38,7 +38,7 @@ def test_dmx_value_range():
     univ_size = 24
     port = DMXConnectionOffline(univ_size=univ_size)
 
-    assert_raises(OverflowError, port.set_channel, 1, -1)
+    assert_raises(ValueError, port.set_channel, 1, -1)
 
     def set_and_check(chan, val):
         port.set_channel(chan, val)
@@ -48,4 +48,4 @@ def test_dmx_value_range():
     set_and_check(0, 128)
     set_and_check(0, 255)
 
-    assert_raises(OverflowError, port.set_channel, 5, 256)
+    assert_raises(ValueError, port.set_channel, 5, 256)

--- a/pyenttec/test.py
+++ b/pyenttec/test.py
@@ -1,5 +1,5 @@
 """Tests for offline DMX port."""
-from nose.tools import assert_equal, assert_raises, raises
+from nose.tools import assert_equal, assert_is, assert_raises, raises
 from . import DMXConnectionOffline
 
 def test_offline_port():
@@ -49,3 +49,12 @@ def test_dmx_value_range():
     set_and_check(0, 255)
 
     assert_raises(ValueError, port.set_channel, 5, 256)
+
+def test_blackout_keeps_array():
+    univ_size = 24
+    port = DMXConnectionOffline(univ_size=univ_size)
+
+    old_frame = port.dmx_frame
+    port.blackout()
+    assert_is(port.dmx_frame, old_frame)
+

--- a/pyenttec/test.py
+++ b/pyenttec/test.py
@@ -1,6 +1,6 @@
 """Tests for offline DMX port."""
 from nose.tools import assert_equal, assert_raises, raises
-from . import DMXConnectionOffline, DMXAddressError, DMXOverflowError
+from . import DMXConnectionOffline
 
 def get_test_port(univ_size=24):
     return DMXConnectionOffline(univ_size=univ_size)
@@ -15,7 +15,7 @@ def test_offline_port():
     port.set_channel(0, 1)
     assert_equal(1, port.dmx_frame[0])
 
-    assert_raises(DMXAddressError, port.set_channel, univ_size, 0)
+    assert_raises(IndexError, port.set_channel, univ_size, 0)
 
 def test_port_item_accessors():
     univ_size = 24
@@ -25,7 +25,7 @@ def test_port_item_accessors():
     port[0] = 2
     assert_equal(2, port.dmx_frame[0])
 
-@raises(DMXAddressError)
+@raises(IndexError)
 def test_port_setitem_max_address():
     univ_size = 24
     port = get_test_port(univ_size)
@@ -34,7 +34,7 @@ def test_port_setitem_max_address():
 def test_dmx_value_range():
     port = get_test_port()
 
-    assert_raises(DMXOverflowError, port.set_channel, 1, -1)
+    assert_raises(OverflowError, port.set_channel, 1, -1)
 
     port.set_channel(0, 0)
     assert_equal(0, port.dmx_frame[0])
@@ -45,4 +45,4 @@ def test_dmx_value_range():
     port.set_channel(0, 255)
     assert_equal(255, port.dmx_frame[0])
 
-    assert_raises(DMXOverflowError, port.set_channel, 5, 256)
+    assert_raises(OverflowError, port.set_channel, 5, 256)

--- a/pyenttec/test.py
+++ b/pyenttec/test.py
@@ -1,5 +1,5 @@
 """Tests for offline DMX port."""
-from nose.tools import assert_equal, assert_raises
+from nose.tools import assert_equal, assert_raises, raises
 from . import DMXConnectionOffline, DMXAddressError, DMXOverflowError
 
 def get_test_port(univ_size=24):
@@ -14,10 +14,22 @@ def test_offline_port():
 
     port.set_channel(0, 1)
     assert_equal(1, port.dmx_frame[0])
-    assert_equal(1, port[0])
 
     assert_raises(DMXAddressError, port.set_channel, univ_size, 0)
-    assert_raises(DMXAddressError, lambda c, v: port[c] = v, univ_size, 0)
+
+def test_port_item_accessors():
+    univ_size = 24
+    port = get_test_port(univ_size)
+    port[univ_size - 1] = 2
+    assert_equal(2, port.dmx_frame[univ_size - 1])
+    port[0] = 2
+    assert_equal(2, port.dmx_frame[0])
+
+@raises(DMXAddressError)
+def test_port_setitem_max_address():
+    univ_size = 24
+    port = get_test_port(univ_size)
+    port[univ_size] = 2
 
 def test_dmx_value_range():
     port = get_test_port()

--- a/pyenttec/test.py
+++ b/pyenttec/test.py
@@ -2,12 +2,9 @@
 from nose.tools import assert_equal, assert_raises, raises
 from . import DMXConnectionOffline
 
-def get_test_port(univ_size=24):
-    return DMXConnectionOffline(univ_size=univ_size)
-
 def test_offline_port():
     univ_size = 24
-    port = get_test_port(univ_size)
+    port = DMXConnectionOffline(univ_size=univ_size)
 
     assert_equal(univ_size, len(port.dmx_frame))
     assert all(chan == 0 for chan in port.dmx_frame)
@@ -19,7 +16,7 @@ def test_offline_port():
 
 def test_port_item_accessors():
     univ_size = 24
-    port = get_test_port(univ_size)
+    port = DMXConnectionOffline(univ_size=univ_size)
     port[univ_size - 1] = 2
     assert_equal(2, port.dmx_frame[univ_size - 1])
     port[0] = 2
@@ -28,21 +25,21 @@ def test_port_item_accessors():
 @raises(IndexError)
 def test_port_setitem_max_address():
     univ_size = 24
-    port = get_test_port(univ_size)
+    port = DMXConnectionOffline(univ_size=univ_size)
     port[univ_size] = 2
 
 def test_dmx_value_range():
-    port = get_test_port()
+    univ_size = 24
+    port = DMXConnectionOffline(univ_size=univ_size)
 
     assert_raises(OverflowError, port.set_channel, 1, -1)
 
-    port.set_channel(0, 0)
-    assert_equal(0, port.dmx_frame[0])
+    def set_and_check(chan, val):
+        port.set_channel(chan, val)
+        assert_equal(val, port[chan])
 
-    port.set_channel(0, 128)
-    assert_equal(128, port.dmx_frame[0])
-
-    port.set_channel(0, 255)
-    assert_equal(255, port.dmx_frame[0])
+    set_and_check(0, 0)
+    set_and_check(0, 128)
+    set_and_check(0, 255)
 
     assert_raises(OverflowError, port.set_channel, 5, 256)

--- a/pyenttec/test.py
+++ b/pyenttec/test.py
@@ -2,9 +2,12 @@
 from nose.tools import assert_equal, assert_raises
 from . import DMXConnectionOffline, DMXAddressError, DMXOverflowError
 
+def get_test_port(univ_size=24):
+    return DMXConnectionOffline(univ_size=univ_size)
+
 def test_offline_port():
     univ_size = 24
-    port = DMXConnectionOffline(univ_size=univ_size)
+    port = get_test_port(univ_size)
 
     assert_equal(univ_size, len(port.dmx_frame))
     assert all(chan == 0 for chan in port.dmx_frame)
@@ -14,6 +17,18 @@ def test_offline_port():
 
     assert_raises(DMXAddressError, port.set_channel, univ_size, 0)
 
+def test_dmx_value_range():
+    port = get_test_port()
+
     assert_raises(DMXOverflowError, port.set_channel, 1, -1)
+
+    port.set_channel(0, 0)
+    assert_equal(0, port.dmx_frame[0])
+
+    port.set_channel(0, 128)
+    assert_equal(128, port.dmx_frame[0])
+
+    port.set_channel(0, 255)
+    assert_equal(255, port.dmx_frame[0])
 
     assert_raises(DMXOverflowError, port.set_channel, 5, 256)

--- a/pyenttec/test.py
+++ b/pyenttec/test.py
@@ -1,6 +1,6 @@
 """Tests for offline DMX port."""
 from nose.tools import assert_equal, assert_raises
-from . import DMXConnectionOffline, DMXAddressError
+from . import DMXConnectionOffline, DMXAddressError, DMXOverflowError
 
 def test_offline_port():
     univ_size = 24
@@ -13,3 +13,7 @@ def test_offline_port():
     assert_equal(1, port.dmx_frame[0])
 
     assert_raises(DMXAddressError, port.set_channel, univ_size, 0)
+
+    assert_raises(DMXOverflowError, port.set_channel, 1, -1)
+
+    assert_raises(DMXOverflowError, port.set_channel, 5, 256)

--- a/pyenttec/test.py
+++ b/pyenttec/test.py
@@ -17,16 +17,22 @@ def test_offline_port():
 def test_port_item_accessors():
     univ_size = 24
     port = DMXConnectionOffline(univ_size=univ_size)
-    port[univ_size - 1] = 2
-    assert_equal(2, port.dmx_frame[univ_size - 1])
-    port[0] = 2
-    assert_equal(2, port.dmx_frame[0])
 
-@raises(IndexError)
+    for i in range(univ_size):
+        port[i] = i
+        assert_equal(i, port.dmx_frame[i])
+        assert_equal(i, port[i])
+
 def test_port_setitem_max_address():
     univ_size = 24
     port = DMXConnectionOffline(univ_size=univ_size)
-    port[univ_size] = 2
+
+    def assert_fail_set_index(i):
+        with assert_raises(IndexError):
+            port[i] = 0
+    # assert_fail_set_index(-1)
+    assert_fail_set_index(univ_size)
+    assert_fail_set_index(univ_size + 1)
 
 def test_dmx_value_range():
     univ_size = 24


### PR DESCRIPTION
I've started using `array.array` and `int.to_bytes` to handle integer -> bytes conversions rather than `chr` and `bytes.join`. Since we're now using a byte array for the `dmx_frame` it's impossible to try and send out of range values.

All these changes are backwards compatible.

Thanks for this library!